### PR TITLE
Fix default WebStorm path

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -40,7 +40,7 @@
       "type": "input",
       "name": "Webstorm recent projects file",
       "description": "The path to the location of the recent files in Webstorm",
-      "default_value": "~/.Webstorm2018.1/config/options/recentProjectDirectories.xml"
+      "default_value": "~/.WebStorm2018.1/config/options/recentProjectDirectories.xml"
     },
     {
       "id": "webstorm_launch_script",


### PR DESCRIPTION
Default WebStorm path has a "S" in the folder name.

For the future it might be even nice to show to the end-user if no `recentProjectDirectories.xml` file was found.

Thanks for the useful plugin.