### PR TITLE
Fix recent projects file path for Android Studio

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -188,7 +188,7 @@
       "type": "input",
       "name": "Open Project in AndroidStudio",
       "description": "The path to the location of the recent files in AndroidStudio",
-      "default_value": "~/.AndroidStudio3.5/config/options/recentProjectDirectories.xml"
+      "default_value": "~/.AndroidStudio3.5/config/options/recentProjects.xml"
     },
     {
       "id": "androidstudio_launch_script",


### PR DESCRIPTION
androidstudio keyword didn't show any projects.

The default path to the recent projects file seems to be wrong.

This works with Android Studio 3.5
`~/.AndroidStudio3.5/config/options/recentProjects.xml`