### PR TITLE
show project icon in result list if available

### DIFF
--- a/jetbrains/project_parser.py
+++ b/jetbrains/project_parser.py
@@ -2,6 +2,7 @@
 Parses the Jetbrains based IDEs recent projects list
 """
 
+import glob
 import os
 import xml.etree.ElementTree as ET
 
@@ -30,13 +31,15 @@ class RecentProjectsParser():
             project_path = project.attrib["value"].replace(
                 '$USER_HOME$', os.path.expanduser('~'))
             project_name = os.path.basename(project_path)
+            icons = glob.glob(os.path.join(project_path, '.idea', 'icon.*'))
 
             if query and query.lower() not in project_name.lower():
                 continue
 
             result.append({
                 'name': project_name,
-                'path': project_path
+                'path': project_path,
+                'icon': icons[0] if len(icons) > 0 else None
             })
 
         return result[:8]

--- a/main.py
+++ b/main.py
@@ -76,7 +76,7 @@ class KeywordQueryEventListener(EventListener):
             ])
         for project in projects:
             items.append(ExtensionResultItem(
-                icon=extension.get_icon(keyword),
+                icon=project['icon'] if project['icon'] is not None else extension.get_icon(keyword),
                 name=project['name'],
                 description=project['path'],
                 on_enter=RunScriptAction('%s "%s" &' % (


### PR DESCRIPTION
Show the project icons in the result list if available. If a project doesn't have an icon, the default icon is used using the existing `get_icon` method.

![image](https://user-images.githubusercontent.com/576772/82199105-8c869700-98fd-11ea-80e7-8d954a365cf0.png)
