### PR TITLE
update default value for pstorm_projects_file using new config folder for PhpStorm >= 2020.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,7 @@
       "type": "input",
       "name": "Open Project in PHPStorm",
       "description": "The path to the location of the recent files in PHPstorm",
-      "default_value": "~/.PhpStorm2019.3/config/options/recentProjectDirectories.xml"
+      "default_value": "~/.config/JetBrains/PhpStorm2020.1/options/recentProjects.xml"
     },
     {
       "id": "pstorm_launch_script",


### PR DESCRIPTION
Update the default value for `pstorm_projects_file` since PhpStorm seems to have changed its configuration folder path and structure.

Closes https://github.com/brpaz/ulauncher-jetbrains/issues/16