### PR TITLE
feat: match file path as well

### DIFF
--- a/jetbrains/project_parser.py
+++ b/jetbrains/project_parser.py
@@ -4,6 +4,7 @@ Parses the Jetbrains based IDEs recent projects list
 
 import glob
 import os
+import re
 import xml.etree.ElementTree as ET
 
 
@@ -21,9 +22,9 @@ class RecentProjectsParser():
 
         root = ET.parse(file_path).getroot()
 
-        recent_projects = root.findall(
+        recent_projects = root.findall(  # recent projects in products version 2020.2 and below
             './/component[@name="RecentProjectsManager"][1]/option[@name="recentPaths"]/list/option'
-        ) + root.findall(
+        ) + root.findall(  # recent projects in products version 2020.2 and below
             './/component[@name="RecentDirectoryProjectsManager"][1]/option[@name="recentPaths"]/list/option'
         ) + root.findall(  # projects in groups in products version 2020.3+
             './/component[@name="RecentProjectsManager"][1]/option[@name="groups"]/list/ProjectGroup/option'
@@ -32,35 +33,42 @@ class RecentProjectsParser():
             './/component[@name="RecentProjectsManager"][1]/option[@name="additionalInfo"]/map/entry'
         )
 
+        home = os.path.expanduser('~')
+        query = query.lower() if query else ''
+        # extract all the words (delimited by " " or "/") from the query.
+        # we will match them against the title and the path of the project.
+        words = [word.lower() for word in re.split('[ /]+', query)]
+
         result = []
         already_matched = []
+
         for project in recent_projects:
-            project_title = ''
-            project_path = (project.attrib['value' if 'value' in project.attrib else 'key']).replace(
-                '$USER_HOME$', os.path.expanduser('~'))
-            name_file = project_path + '/.idea/.name'
+            title = ''
+            path = (project.attrib['value' if 'value' in project.attrib else 'key']).replace('$USER_HOME$', home)
+            title_file = path + '/.idea/.name'
 
-            if os.path.exists(name_file):
-                with open(name_file, 'r') as file:
-                    project_title = file.read().replace('\n', '')
+            if os.path.exists(title_file):
+                with open(title_file, 'r') as file:
+                    title = file.read().replace('\n', '').lower()
 
-            project_name = os.path.basename(project_path)
-            icons = glob.glob(os.path.join(project_path, '.idea', 'icon.*'))
+            icons = glob.glob(os.path.join(path, '.idea', 'icon.*'))
 
-            if query and query.lower() not in project_name.lower(
-            ) and query.lower() not in project_title.lower():
+            # match all words from the query to the path and the title of the project
+            matched_words = [word for word in words if word in '{} {}'.format(title, path)]
+
+            if query and len(matched_words) < len(words):
                 continue
 
             # prevent duplicate results, because from version 2020.3, a project can appear more than once in the XML
             # (in the option[@name="groups"] section and in the option[@name="additionalInfo"] section)
-            if project_path in already_matched:
+            if path in already_matched:
                 continue
 
-            already_matched.append(project_path)
+            already_matched.append(path)
 
             result.append({
-                'name': project_title or project_name,
-                'path': project_path,
+                'name': title or os.path.basename(path).lower(),
+                'path': path,
                 'icon': icons[0] if len(icons) > 0 else None
             })
 


### PR DESCRIPTION
With this PR, the extension now also matches the query typed in ULauncher to the **path** of the project as well, and not only its name or custom title (in `.idea/.name`).

It supports multi-word queries (delimited by "` `" or "`/`").

The rationale behind this is the following : 

I do a lot of work for several clients with the same project strucutres : an `api` project and a `front-end` project. As a result, my projects are organized like so :

```
~/Workspace
├── bob
│   ├── api
│   └── front-end
├── alice
│   ├── api
│   └── front-end
└── carol
    ├── api
    └── front-end
```

In this example, when I'm searching for `api` in ULauncher, the extension returns the 3 projects named `api` (`bob/api`, `alice/api` and `carol/api`) and I can't do anything to be more specific. Instead, I have to use the <kbd>Up</kbd> or <kbd>Down</kbd> arrows to select the right project.

With this PR, this default behavior is left untouched. However, if I add more words to my query, the results are filtered more precisely. For example, typing `bob api` will only return the project in `~/Workspace/bob/api`.

Using the query `carol` would present the 2 projects `carol/api` and `carol/front`.